### PR TITLE
Fully declarative wallpapers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ Then in a new terminal we can open the spotify TUI
 spt
 # proceed to jam out
 ```
+
+### Other Resources
+
+* [nix-starter-configs](https://github.com/Misterio77/nix-starter-configs/tree/main) from Gabriel Fontes, well-documented and modern flake setup.

--- a/base.nix
+++ b/base.nix
@@ -1,13 +1,20 @@
 # Base configuration shared across all machines.
 
-{ config, pkgs, lib, ... }:
+{ config, pkgs, lib, inputs, outputs, ... }:
 let
   system-font = "JetBrains Mono";
   i3lock-wrap = pkgs.callPackage ./i3lock-wrap.nix { };
   nixpkgs-cfg-path = ./nixpkgs-config.nix;
 in
 {
-  config = {
+  config = { 
+    services.wallsetter = {
+      enable = true;
+      user = "trey";
+      repo = outputs.packages.x86_64-linux.wallpapers;
+      wallpaper = "monolith.jpg";
+    };
+
     # Use the systemd-boot EFI boot loader.
     boot.loader.systemd-boot.enable = true;
     boot.loader.efi.canTouchEfiVariables = true;
@@ -61,13 +68,9 @@ in
       # Configure keymap in X11
       layout = "us";
 
-      # TODO: deliver this to all systems
-      # This uses the file at ~/.background-image as the wallpaper.
-      # 
-      # You can restart the display-manager with:
-      #   sudo systemctl restart display-manager
-      # 
-      # Note that will kill all graphical programs and log you out...
+      # By default, the desktop manager will look for a file called
+      # ~/.background-image as the wallpaper, but this doesn't have nice
+      # facilities for reloading at runtime so I made "wallsetter" for myself.
       desktopManager.wallpaper.mode = "fill";
       displayManager.defaultSession = "none+i3";
 
@@ -469,6 +472,9 @@ in
       nix-diff
       socat
       remmina
+      feh
+      git-lfs
+      setroot
     ];
 
     fonts.fonts = with pkgs; [ jetbrains-mono ];

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,16 @@
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, home-manager, ... }@inputs: {
+  outputs = { self, nixpkgs, home-manager, ... }@inputs: 
+  let
+    inherit (self) outputs;
+  in {
+    packages.x86_64-linux = let 
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+    in {
+      wallpapers = pkgs.callPackage ./wallpapers { };
+    };
+
     nixosConfigurations = {
       # Custom desktop build, NZXT case
       kearsarge = nixpkgs.lib.nixosSystem {
@@ -17,7 +26,7 @@
           self.nixosModules.base
           ./kearsarge/configuration.nix
         ];
-        specialArgs = { inherit inputs; };
+        specialArgs = { inherit inputs outputs; };
       };
 
       # TODO... add the 2002 Nuc
@@ -25,13 +34,16 @@
     };
 
     nixosModules = {
-      # The base configuration to be dependended on private machines
+      # The base configuration to be depended on by privately-managed machines
       base = { ... }: {
         imports = [
           home-manager.nixosModules.home-manager
+          self.nixosModules.wallsetter
           ./base.nix
         ];
       };
+
+      wallsetter = import ./wallpapers/module.nix;
     };
   };
 }

--- a/wallpapers/default.nix
+++ b/wallpapers/default.nix
@@ -1,0 +1,11 @@
+{ fetchgit
+,
+}:
+fetchgit {
+  url = "https://github.com/treyfortmuller/wallpapers.git";
+  branchName = "master";
+  sha256 = "sha256-3Y5N18766e9YN1mMQX1kGcCrP+Hi4yI2MDo6ioZWp9E=";
+
+  # Wallpapers in this repo are all tracked with LFS
+  fetchLFS = true;
+}

--- a/wallpapers/module.nix
+++ b/wallpapers/module.nix
@@ -1,0 +1,54 @@
+{ pkgs, config, lib, ... }:
+with lib;
+let
+  cfg = config.services.wallsetter;
+in
+{
+  options.services.wallsetter = {
+    enable = mkEnableOption "wallsetter oneshot service";
+
+    repo = mkOption {
+      type = types.package;
+      description = ''
+        The repo to pull wallpapers from. The requirements on it are just to
+        have a `wallpapers/` directory in the root of the repo full of jpgs of the
+        correct size for the monitor we're using.
+      '';
+    };
+
+    user = mkOption {
+      type = types.str;
+      description = "User account under which wallsetter runs.";
+    };
+
+    wallpaper = mkOption {
+      type =
+        let
+          wallpaperContents = attrNames (builtins.readDir (cfg.repo + "/wallpapers"));
+          wallpapers = filter (f: hasSuffix ".jpg" f) wallpaperContents;
+        in
+        types.enum wallpapers;
+      default = "monolith.jpg";
+      description = "The wallpaper to set as the desktop background";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.wallsetter = {
+      enable = true;
+      description = "Wallpaper background image setter";
+      wantedBy = [ "multi-user.target" ];
+      script =
+        ''
+          ${pkgs.setroot}/bin/setroot --center ${cfg.repo}/wallpapers/${cfg.wallpaper}
+        '';
+      serviceConfig = {
+        User = cfg.user;
+        Environment = [
+          "DISPLAY=:0"
+        ];
+        Type = "oneshot";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Tracking wallpapers via Git LFS in this repo: https://github.com/treyfortmuller/wallpapers

and then fetching them with a derivation checked into this repo, deployed with a oneshot daemon I wrote a module for here.