### PR TITLE
Try to fix downstream of wallsetter

### DIFF
--- a/base.nix
+++ b/base.nix
@@ -11,7 +11,6 @@ in
     services.wallsetter = {
       enable = true;
       user = "trey";
-      repo = outputs.packages.x86_64-linux.wallpapers;
       wallpaper = "monolith.jpg";
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,10 +8,7 @@
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, home-manager, ... }@inputs: 
-  let
-    inherit (self) outputs;
-  in {
+  outputs = { self, nixpkgs, home-manager, ... }@inputs: {
     packages.x86_64-linux = let 
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
     in {
@@ -26,7 +23,7 @@
           self.nixosModules.base
           ./kearsarge/configuration.nix
         ];
-        specialArgs = { inherit inputs outputs; };
+        specialArgs = { inherit inputs; };
       };
 
       # TODO... add the 2002 Nuc
@@ -43,7 +40,14 @@
         ];
       };
 
-      wallsetter = import ./wallpapers/module.nix;
+      wallsetter = { ... }: {
+        imports = [
+          ./wallpapers/module.nix
+        ];
+        services.wallsetter.repo = self.packages.x86_64-linux.wallpapers;
+      };
     };
+
+    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixpkgs-fmt;
   };
 }

--- a/wallpapers/default.nix
+++ b/wallpapers/default.nix
@@ -4,7 +4,7 @@
 fetchgit {
   url = "https://github.com/treyfortmuller/wallpapers.git";
   branchName = "master";
-  sha256 = "sha256-3Y5N18766e9YN1mMQX1kGcCrP+Hi4yI2MDo6ioZWp9E=";
+  sha256 = "sha256-KMDdgGo3CuOkp7D3hx37wP+ijIJ76NmiDODOQwmN5yU=";
 
   # Wallpapers in this repo are all tracked with LFS
   fetchLFS = true;


### PR DESCRIPTION
We were running into an issue where passing `outputs` via `specialArgs` into the `base.nix` caused eval issues for downstream consumers like this:

```
       … while evaluating the option `services.wallsetter.repo':

       … while calling anonymous lambda

         at /nix/store/4a3qxnlq7r1gjwfjfqrizpf30hh22bz1-source/lib/modules.nix:774:28:

          773|         # Process mkMerge and mkIf properties.
          774|         defs' = concatMap (m:
             |                            ^
          775|           map (value: { inherit (m) file; inherit value; }) (builtins.addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))

       … while evaluating definitions from `/nix/store/q3jjdyqzba9q44gqpcf0xaglc752hxha-source/base.nix':

       … from call site

         at /nix/store/4a3qxnlq7r1gjwfjfqrizpf30hh22bz1-source/lib/modules.nix:775:137:

          774|         defs' = concatMap (m:
          775|           map (value: { inherit (m) file; inherit value; }) (builtins.addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
             |                                                                                                                                         ^
          776|         ) defs;

       … while calling 'dischargeProperties'

         at /nix/store/4a3qxnlq7r1gjwfjfqrizpf30hh22bz1-source/lib/modules.nix:846:25:

          845|   */
          846|   dischargeProperties = def:
             |                         ^
          847|     if def._type or "" == "merge" then

       … while calling anonymous lambda

         at /nix/store/4a3qxnlq7r1gjwfjfqrizpf30hh22bz1-source/lib/modules.nix:510:44:

          509|       context = name: ''while evaluating the module argument `${name}' in "${key}":'';
          510|       extraArgs = builtins.mapAttrs (name: _:
             |                                            ^
          511|         builtins.addErrorContext (context name)

       … while evaluating the module argument `outputs' in "/nix/store/q3jjdyqzba9q44gqpcf0xaglc752hxha-source/base.nix":

       error: attribute 'outputs' missing

       at /nix/store/4a3qxnlq7r1gjwfjfqrizpf30hh22bz1-source/lib/modules.nix:512:28:

          511|         builtins.addErrorContext (context name)
          512|           (args.${name} or config._module.args.${name})
             |                            ^
          513|       ) (lib.functionArgs f);
```

We switched to including the defaults for the wallpaper settings in the output wallsetter module which is consumed by `nixosModules.base`

if the file isn't in your flake repo, it doesn't exist according to flakes